### PR TITLE
Strict Standards

### DIFF
--- a/include/SubPanel/SubPanel.php
+++ b/include/SubPanel/SubPanel.php
@@ -242,7 +242,7 @@ class SubPanel
 		return $modules;
 	}
 
-  function getModuleSubpanels($module){
+  static function getModuleSubpanels($module){
   	require_once('include/SubPanel/SubPanelDefinitions.php');
   		global $beanList, $beanFiles;
   		if(!isset($beanList[$module])){


### PR DESCRIPTION
Non-static method CLASS::METHOD() should not be called statically in file.php on line X

Added static to function statement to avoid PHP error when the function is called statically.